### PR TITLE
получение названия модели телевизора LG

### DIFF
--- a/src/platforms/lg/sb.platform.lg.js
+++ b/src/platforms/lg/sb.platform.lg.js
@@ -52,7 +52,7 @@ SB.createPlatform('lg', {
         this.device = $('#device')[0];
 
         this.modelCode = this.device.version;
-        this.productCode = this.device.platform;
+        this.productCode = this.device.modelName;
 
         this.getDUID();
 


### PR DESCRIPTION
У Samsung и LG будет теперь будет единообразно заполняться поле `productCode`.
Названия полей похоже взяты из API Samsung, потому что на LG нет отдельного кода серии и кода модели.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/PLoginoff%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3222658%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/immosmart/smartbox/pull/77%23issuecomment-83125160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-03-18T19%3A12%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3222658%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/PLoginoff%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/immosmart/smartbox/pull/77%23issuecomment-83125160%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/PLoginoff'><img src='https://avatars.githubusercontent.com/u/3222658?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/immosmart/smartbox/pull/77?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/immosmart/smartbox/pull/77?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/immosmart/smartbox/pull/77'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>